### PR TITLE
Fix final period return to use last trading day

### DIFF
--- a/strategies/low_ttm_pe_strategy.py
+++ b/strategies/low_ttm_pe_strategy.py
@@ -379,6 +379,7 @@ class LowTTMPEStrategy:
         # 获取交易日期
         trading_dates = self.get_trading_dates()
         month_end_dates = self.get_month_end_dates(trading_dates)
+        final_trading_date = trading_dates[-1]
         
         # 初始化
         current_nav = 1.0
@@ -447,28 +448,38 @@ class LowTTMPEStrategy:
             # 更新上一期选股日期
             prev_selection_date = selection_date
         
-        # 计算最后一期收益（从最后一次选股到回测结束日）
-        if not current_positions.empty and prev_selection_date and prev_selection_date != self.end_date:
+        # 计算最后一期收益（从最后一次选股到最后一个交易日）
+        if not current_positions.empty and prev_selection_date and prev_selection_date < final_trading_date:
             final_return = self.calculate_period_return(
-                current_positions, prev_selection_date, self.end_date)
+                current_positions, prev_selection_date, final_trading_date)
             current_nav *= (1 + final_return - self.transaction_cost)
             print(f"📈 最后一期收益率: {final_return*100:.2f}%, 净值: {current_nav:.4f}")
-            
+
             # 记录最后一期收益
             self.period_returns.append({
                 'period': len(self.positions) + 1,
                 'start_date': prev_selection_date,
-                'end_date': self.end_date,
+                'end_date': final_trading_date,
                 'return': final_return,
                 'nav_before': current_nav / (1 + final_return - self.transaction_cost),
                 'nav_after': current_nav
             })
-            
+
             # 记录最后净值
-            self.nav_history.append({
-                'date': self.end_date,
-                'nav': current_nav
-            })
+            if self.nav_history and self.nav_history[-1]['date'] == final_trading_date:
+                self.nav_history[-1]['nav'] = current_nav
+            else:
+                self.nav_history.append({
+                    'date': final_trading_date,
+                    'nav': current_nav
+                })
+        else:
+            # 确保净值曲线以最后一个交易日收尾
+            if self.nav_history and self.nav_history[-1]['date'] != final_trading_date:
+                self.nav_history.append({
+                    'date': final_trading_date,
+                    'nav': current_nav
+                })
         
         
         print(f"\n🎯 回测完成!")


### PR DESCRIPTION
## Summary
- ensure the backtest's final period uses the final available trading day instead of the configured end date when computing returns
- update net value tracking to align the last entry with the actual final trading session and avoid duplicate records

## Testing
- python -m compileall strategies/low_ttm_pe_strategy.py

------
https://chatgpt.com/codex/tasks/task_e_68ccc49ef9b88328a7dcb1aa1beb5a2a